### PR TITLE
Zipkin exporter issue

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
@@ -183,6 +183,15 @@ class ZipkinSpanExporter(SpanExporter):
                     "otel.instrumentation_library.version"
                 ] = span.instrumentation_info.version
 
+            if span.status is not None:
+                zipkin_span["tags"][
+                    "ot.status_code"
+                ] = span.status.canonical_code.value
+                if span.status.description is not None:
+                    zipkin_span["tags"][
+                        "ot.status_description"
+                    ] = span.status.description
+
             if context.trace_flags.sampled:
                 zipkin_span["debug"] = True
 

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -213,6 +213,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                     "key_bool": "False",
                     "key_string": "hello_world",
                     "key_float": "111.22",
+                    "ot.status_code":0
                 },
                 "annotations": [
                     {
@@ -231,7 +232,10 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "duration": durations[1] // 10 ** 3,
                 "localEndpoint": local_endpoint,
                 "kind": None,
-                "tags": {"key_resource": "some_resource"},
+                "tags": {
+                    "key_resource": "some_resource",
+                    "ot.status_code":0
+                },
                 "annotations": None,
             },
             {
@@ -245,6 +249,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "tags": {
                     "key_string": "hello_world",
                     "key_resource": "some_resource",
+                    "ot.status_code":0
                 },
                 "annotations": None,
             },
@@ -259,6 +264,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "tags": {
                     "otel.instrumentation_library.name": "name",
                     "otel.instrumentation_library.version": "version",
+                    "ot.status_code":0
                 },
                 "annotations": None,
             },
@@ -324,7 +330,9 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "duration": duration // 10 ** 3,
                 "localEndpoint": local_endpoint,
                 "kind": None,
-                "tags": {},
+                "tags": {
+                    "ot.status_code":0
+                },
                 "annotations": None,
                 "debug": True,
                 "parentId": "0aaaaaaaaaaaaaaa",


### PR DESCRIPTION
This PR adds status to the tags for the Zipkin Exporter, closing https://github.com/open-telemetry/opentelemetry-python/issues/1111. 

The changes have been made following these specifications:
https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md#status