### PR TITLE
Add Unit tests and Base Class for Prometheus Remote Write Exporter

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/LICENSE
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/setup.cfg
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/setup.cfg
@@ -1,0 +1,54 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-exporter-prometheus-remote-write
+description = OpenTelemetry Prometheus Remote Write Exporter
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/tree/master/exporter/opentelemetry-prometheus-remote-write
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.5
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    grpcio >= 1.0.0, < 2.0.0
+    googleapis-common-protos ~= 1.52.0
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
+    opentelemetry-proto == 0.16.dev0
+    backoff ~= 1.10.0
+
+[options.extras_require]
+test =
+    pytest-grpc
+
+[options.packages.find]
+where = src

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/setup.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "exporter", "prometheus_remote_write", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -1,0 +1,134 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from opentelemetry.sdk.metrics.export import (
+    MetricRecord,
+    MetricsExporter,
+    MetricsExportResult,
+)
+
+from opentelemetry.sdk.metrics.export.aggregate import (
+    ValueObserverAggregator,
+    LastValueAggregator,
+    HistogramAggregator,
+    MinMaxSumCountAggregator,
+    SumAggregator,
+)
+
+class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
+    """
+    Prometheus remote write metric exporter for OpenTelemetry.
+
+    Args:
+        config: configuration object containing all necessary information to make remote write requests
+    """
+
+    def __init__(self, prefix: str = ""):
+        pass
+
+    def export(self, metric_records: Sequence[MetricRecord]) -> MetricsExportResult:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+    
+    def convert_to_timeseries(self, metric_records: Sequence[MetricRecord]) -> Sequence[TimeSeriesData]:
+        pass
+    
+    def convert_from_sum(self, sum_record: MetricRecord) -> TimeSeriesData:
+        pass
+
+    def convert_from_min_max_sum_count(self, min_max_sum_count_record: MetricRecord) -> TimeSeriesData:
+        pass
+
+    def convert_from_histogram(self, histogram_record: MetricRecord) -> TimeSeriesData:
+        pass
+
+    def convert_from_last_value(self, last_value_record: MetricRecord) -> TimeSeriesData:
+        pass
+
+    def convert_from_value_observer(self, value_observer_record: MetricRecord) -> TimeSeriesData:
+        pass
+
+    def convert_from_summary(self, summary_record: MetricRecord) -> TimeSeriesData:
+        pass
+
+    def build_message(self) -> String:
+        pass
+
+    def get_headers(self) -> dict:
+        pass
+
+    def send_message(self, message: String) -> bool:
+        pass
+
+    def build_client(self) -> HTTPConnection:
+        pass
+
+    def build_tls_config(self) -> TLSConfig:
+        pass
+
+    def sanitize_label(self, label: String) -> String:
+        pass
+
+
+class Config():
+    """
+    Configuration containing all necessary information to make remote write requests
+    
+    Args:
+        config_dict: dictionary containing all config properties
+    """
+
+    def __init__(self):
+        pass
+
+    def validate(self):
+        pass
+
+
+class TLSConfig():
+    """
+    Configuration containing all necessary information to add TLS to HTTPConnection
+    
+    Args:
+        ca_file: dictionary containing all config properties
+    """
+
+    def __init__(self):
+        pass
+
+    def validate(self):
+        pass
+
+class TimeSeriesData:
+    def __init__(self, labels, samples):
+        self.labels = labels
+        self.samples = samples
+
+    def __eq__(self, other) -> bool:
+        if len(self.labels) != len(other.labels) or len(self.samples) != len(other.samples):
+            return False
+        for i in range(len(labels)):
+            if self.labels[i] != other.labels[i]:
+                return False
+
+        for i in range(len(samples)):
+            if self.samples[i] != other.samples[i]:
+                return False
+        return True
+
+def parse_config(filepath: String) -> Config:
+    pass

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -65,6 +65,9 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     def convert_from_summary(self, summary_record: MetricRecord) -> TimeSeriesData:
         pass
 
+    def sanitize_label(self, label: str) -> str:
+        pass
+
     def build_message(self, data: Sequence[TimeSeries]) -> str:
         pass
 
@@ -80,8 +83,6 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     def build_tls_config(self) -> TLSConfig:
         pass
 
-    def sanitize_label(self, label: str) -> str:
-        pass
 
 
 class Config():
@@ -91,7 +92,6 @@ class Config():
     Args:
         config_dict: dictionary containing all config properties
     """
-
     def __init__(self, config_dict):
         pass
 
@@ -106,6 +106,7 @@ class TimeSeriesData:
 
     def __eq__(self, other) -> bool:
         return self.labels == other.labels and self.samples == other.samples
+
 
 def parse_config(filepath: str) -> Config:
     pass

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -65,13 +65,13 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     def convert_from_summary(self, summary_record: MetricRecord) -> TimeSeriesData:
         pass
 
-    def build_message(self) -> String:
+    def build_message(self, data: Sequence[TimeSeries]) -> str:
         pass
 
     def get_headers(self) -> dict:
         pass
 
-    def send_message(self, message: String) -> bool:
+    def send_message(self, message: str) -> int:
         pass
 
     def build_client(self) -> HTTPConnection:
@@ -80,7 +80,7 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     def build_tls_config(self) -> TLSConfig:
         pass
 
-    def sanitize_label(self, label: String) -> String:
+    def sanitize_label(self, label: str) -> str:
         pass
 
 
@@ -92,26 +92,12 @@ class Config():
         config_dict: dictionary containing all config properties
     """
 
-    def __init__(self):
+    def __init__(self, config_dict):
         pass
 
     def validate(self):
         pass
 
-
-class TLSConfig():
-    """
-    Configuration containing all necessary information to add TLS to HTTPConnection
-    
-    Args:
-        ca_file: dictionary containing all config properties
-    """
-
-    def __init__(self):
-        pass
-
-    def validate(self):
-        pass
 
 class TimeSeriesData:
     def __init__(self, labels, samples):
@@ -119,16 +105,7 @@ class TimeSeriesData:
         self.samples = samples
 
     def __eq__(self, other) -> bool:
-        if len(self.labels) != len(other.labels) or len(self.samples) != len(other.samples):
-            return False
-        for i in range(len(labels)):
-            if self.labels[i] != other.labels[i]:
-                return False
+        return self.labels == other.labels and self.samples == other.samples
 
-        for i in range(len(samples)):
-            if self.samples[i] != other.samples[i]:
-                return False
-        return True
-
-def parse_config(filepath: String) -> Config:
+def parse_config(filepath: str) -> Config:
     pass

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -13,19 +13,32 @@
 # limitations under the License.
 
 
+from typing import Dict, Sequence
+
+from http.client import HTTPSConnection
+
 from opentelemetry.sdk.metrics.export import (
     MetricRecord,
     MetricsExporter,
     MetricsExportResult,
 )
-
 from opentelemetry.sdk.metrics.export.aggregate import (
-    ValueObserverAggregator,
-    LastValueAggregator,
     HistogramAggregator,
+    LastValueAggregator,
     MinMaxSumCountAggregator,
     SumAggregator,
+    ValueObserverAggregator,
 )
+
+
+class TimeSeriesData:
+    def __init__(self, labels, samples):
+        self.labels = labels
+        self.samples = samples
+
+    def __eq__(self, other) -> bool:
+        return self.labels == other.labels and self.samples == other.samples
+
 
 class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     """
@@ -43,10 +56,10 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
 
     def shutdown(self) -> None:
         pass
-    
+
     def convert_to_timeseries(self, metric_records: Sequence[MetricRecord]) -> Sequence[TimeSeriesData]:
         pass
-    
+
     def convert_from_sum(self, sum_record: MetricRecord) -> TimeSeriesData:
         pass
 
@@ -68,27 +81,26 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     def sanitize_label(self, label: str) -> str:
         pass
 
-    def build_message(self, data: Sequence[TimeSeries]) -> str:
+    def build_message(self, data: Sequence[TimeSeriesData]) -> str:
         pass
 
-    def get_headers(self) -> dict:
+    def get_headers(self) -> Dict:
         pass
 
     def send_message(self, message: str) -> int:
         pass
 
-    def build_client(self) -> HTTPConnection:
+    def build_client(self) -> HTTPSConnection:
         pass
 
-    def build_tls_config(self) -> TLSConfig:
+    def build_tls_config(self) -> Dict:
         pass
-
 
 
 class Config():
     """
     Configuration containing all necessary information to make remote write requests
-    
+
     Args:
         config_dict: dictionary containing all config properties
     """
@@ -97,15 +109,6 @@ class Config():
 
     def validate(self):
         pass
-
-
-class TimeSeriesData:
-    def __init__(self, labels, samples):
-        self.labels = labels
-        self.samples = samples
-
-    def __eq__(self, other) -> bool:
-        return self.labels == other.labels and self.samples == other.samples
 
 
 def parse_config(filepath: str) -> Config:

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/version.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.16.dev0"

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -14,8 +14,12 @@
 
 import unittest
 from unittest import mock
+import os
 
 from opentelemetry.exporter.prometheus_remote_write import (
+    sanitize_label,
+    parse_config,
+    TLSConfig,
     TimeSeriesData,
     Config,
     PrometheusRemoteWriteMetricsExporter,
@@ -30,6 +34,7 @@ from opentelemetry.sdk.metrics.export.aggregate import (
     SumAggregator,
 )
 from opentelemetry.sdk.util import get_dict_as_key
+from http.client import HTTPSConnection
 
 class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
     def setUp(self):
@@ -70,3 +75,210 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         timeseries = exporter.convert_from_sum(sum_record)
         self.assertEqual(timeseries, expected_timeseries)
     
+    def test_convert_from_min_max_sum_count(self):
+        min_max_sum_count_record = MetricRecord(
+            self._test_metric,
+            self._labels_key,
+            MinMaxSumCountAggregator(),
+            get_meter_provider().resource,
+        )
+        min_max_sum_count_record.aggregator.update(5)
+        expected_timeseries = TimeSeriesData(
+            [
+                "testname_min",
+                "testname_max",
+                "testname_sum",
+                "testname_count"
+            ], [5,5,5,1]
+        )
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        timeseries = exporter.convert_from_min_max_sum_count(min_max_sum_count_record)
+        self.assertEqual(timeseries, expected_timeseries)
+    
+    def test_convert_from_histogram(self):
+        histogram_record = MetricRecord(
+            self._test_metric,
+            self._labels_key,
+            HistogramAggregator(),
+            get_meter_provider().resource,
+        )
+        histogram_record.aggregator.update(5)
+        expected_timeseries = TimeSeriesData(
+            [
+                "testname_count",
+                "testname_sum",
+                "testname_{le=\"0\"}",
+                "testname_{le=\"+Inf\"}"
+            ], [1,5,0,1]
+        )
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        timeseries = exporter.convert_from_histogram(histogram_record)
+        self.assertEqual(timeseries, expected_timeseries)
+
+    def test_convert_from_last_value(self):
+        last_value_record = MetricRecord(
+            self._test_metric,
+            self._labels_key,
+            LastValueAggregator(),
+            get_meter_provider().resource,
+        )
+        last_value_record.aggregator.update(5)
+        expected_timeseries = TimeSeriesData(["testname"], [5])
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        timeseries = exporter.convert_from_last_value(last_value_record)
+        self.assertEqual(timeseries, expected_timeseries)
+
+    def test_convert_from_value_observer(self):
+        value_observer_record = MetricRecord(
+            self._test_metric,
+            self._labels_key,
+            ValueObserverAggregator(),
+            get_meter_provider().resource,
+        )
+        value_observer_record.aggregator.update(5)
+        expected_timeseries = TimeSeriesData(
+            [
+                "testname_min",
+                "testname_max",
+                "testname_sum",
+                "testname_count",
+                "testname_last_value",
+            ], [5,5,5,1,5]
+        )
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        timeseries = exporter.convert_from_value_observer(value_observer_record)
+        self.assertEqual(timeseries, expected_timeseries)
+
+    def test_convert_to_timeseries(self):
+        empty_timeseries = TimeSeriesData([],[])
+        timeseries_mock_method = Mock(return_value=empty_timeseries)
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        exporter.convert_from_sum = timeseries_mock_method
+        exporter.convert_from_min_max_sum_count = timeseries_mock_method
+        exporter.convert_from_histogram = timeseries_mock_method
+        exporter.convert_from_last_value = timeseries_mock_method
+        exporter.convert_from_value_observer = timeseries_mock_method
+        test_records = [
+            MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                SumAggregator(),
+                get_meter_provider().resource,
+            ), MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                MinMaxSumCountAggregator(),
+                get_meter_provider().resource,
+            ), MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                HistogramAggregator(),
+                get_meter_provider().resource,
+            ), MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                LastValueAggregator(),
+                get_meter_provider().resource,
+            ), MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                ValueObserverAggregator(),
+                get_meter_provider().resource,
+            )
+        ]
+        data = exporter.convert_to_timeseries(test_records)
+        self.assertEqual(len(data), 5)
+        for timeseries in data:
+            self.assertEqual(timeseries, empty_timeseries)
+
+        no_type_records = [
+            MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                None,
+                get_meter_provider().resource,
+            )
+        ]
+        with self.assertRaises(ValueError):
+            exporter.convert_to_timeseries(no_type_records)
+        no_label_records = [
+            MetricRecord(
+                self._test_metric,
+                self._labels_key,
+                None,
+                get_meter_provider().resource,
+            )
+        ]
+        with self.assertRaises(ValueError):
+            exporter.convert_to_timeseries(no_label_records)
+
+    @mock.patch('snappy.compress', return_value=1)
+    def test_build_message(self, mock_compress):
+        data = [
+            TimeSeries(["test_label0"], [0]),
+            TimeSeries(["test_label1"], [1]),
+        ]
+        exporter = PrometheusRemoteWriteExporter(self._test_config)
+        message = exporter.build_message(data)
+        self.assertEqual(mock_compress.call_count, 1)
+        self.assertIsInstance(message, str)
+
+    def test_get_headers(self):
+        test_config = self._test_config
+        test_config["headers"] = {
+            "Custom Header": "test_header"
+        }
+        test_config["bearer_token"] = "test_token"
+        exporter = PrometheusRemoteWriteMetricsExporter(test_config)
+        headers = exporter.get_headers()
+        self.assertEqual(headers["Content-Encoding"], "snappy")
+        self.assertEqual(headers["Content-Type"], "application/x-protobuf")
+        self.assertEqual(headers["X-Prometheus-Remote-Write-Version"], "0.1.0")
+        self.assertEqual(headers["Authorization"], "test_token")
+        self.assertEqual(headers["Custom Header"], "test_header")
+
+    def test_send_request(self):
+        # TODO: Iron out details of test after implementation
+    
+    def test_build_client(self):
+        # TODO: Iron out details of test after implementation
+
+    def test_sanitize_label(self):
+        unsanitized_string = "key/metric@data"
+        sanitized_string = sanitize_label(unsanitized_string)
+        self.assertEqual(valid_string, "key_metric_data")
+
+    def test_valid_yaml_file(self):
+        valid_yml = [
+            {"url": ["https://testurl.com"]},
+            {"name": ["test_name"]},
+            {"remote_timeout": ["30s"]}
+        ]
+        filepath = "./test.yml"
+        with open(filepath, 'w') as file:
+            yaml.dump(dict_file, file)
+        config = parse_config(filepath)
+        os.remove(filepath)
+        self.assertEqual(config["url"], "https://testurl.com")
+        self.assertEqual(config["name"], "test_name")
+        self.assertEqual(config["remote_timeout"], "30s")
+
+    def test_invalid_yaml_file(self):
+        filepath = "invalid filepath"
+        with self.assertRaises(ValueError):
+            parse_config(filepath)
+
+
+    class TestConfig(unittest.TestCase):
+        def test_valid_standard_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+            })
+            try:
+                config.validate()
+            except as exception:
+                self.fail("valid config failed config.validate() with error:" + exception)
+
+        # TODO: Add other config validity test cases

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -51,6 +51,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         labels = {"environment": "staging"}
         self._labels_key = get_dict_as_key(labels)
 
+    # TODO: Add documentation before each test
     def test_export(self):
         record = MetricRecord(
             self._test_metric,

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -37,6 +37,7 @@ from opentelemetry.sdk.util import get_dict_as_key
 from http.client import HTTPSConnection
 
 class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
+    # Initializes test data that is reused across tests
     def setUp(self):
         set_meter_provider(metrics.MeterProvider())
         self._test_config = Config({
@@ -51,7 +52,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         labels = {"environment": "staging"}
         self._labels_key = get_dict_as_key(labels)
 
-    # TODO: Add documentation before each test
+    # Ensures export is successful with valid metric_records and config
     def test_export(self):
         record = MetricRecord(
             self._test_metric,
@@ -63,6 +64,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         result = exporter.export([record])
         self.assertIs(result, MetricsExportResult.SUCCESS)
     
+    # Ensures sum aggregator is correctly converted to timeseries
     def test_convert_from_sum(self):
         sum_record = MetricRecord(
             self._test_metric,
@@ -76,6 +78,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         timeseries = exporter.convert_from_sum(sum_record)
         self.assertEqual(timeseries, expected_timeseries)
     
+    # Ensures sum min_max_count aggregator is correctly converted to timeseries
     def test_convert_from_min_max_sum_count(self):
         min_max_sum_count_record = MetricRecord(
             self._test_metric,
@@ -96,6 +99,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         timeseries = exporter.convert_from_min_max_sum_count(min_max_sum_count_record)
         self.assertEqual(timeseries, expected_timeseries)
     
+    # Ensures histogram aggregator is correctly converted to timeseries
     def test_convert_from_histogram(self):
         histogram_record = MetricRecord(
             self._test_metric,
@@ -116,6 +120,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         timeseries = exporter.convert_from_histogram(histogram_record)
         self.assertEqual(timeseries, expected_timeseries)
 
+    # Ensures last value aggregator is correctly converted to timeseries
     def test_convert_from_last_value(self):
         last_value_record = MetricRecord(
             self._test_metric,
@@ -129,6 +134,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         timeseries = exporter.convert_from_last_value(last_value_record)
         self.assertEqual(timeseries, expected_timeseries)
 
+    # Ensures value observer aggregator is correctly converted to timeseries
     def test_convert_from_value_observer(self):
         value_observer_record = MetricRecord(
             self._test_metric,
@@ -150,6 +156,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         timeseries = exporter.convert_from_value_observer(value_observer_record)
         self.assertEqual(timeseries, expected_timeseries)
 
+    # Ensures conversion to timeseries function as expected for different aggregation types
     def test_convert_to_timeseries(self):
         empty_timeseries = TimeSeriesData([],[])
         timeseries_mock_method = Mock(return_value=empty_timeseries)
@@ -213,6 +220,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         with self.assertRaises(ValueError):
             exporter.convert_to_timeseries(no_label_records)
 
+    # Verifies that build_message calls snappy.compress and returns SerializedString
     @mock.patch('snappy.compress', return_value=1)
     def test_build_message(self, mock_compress):
         data = [
@@ -224,6 +232,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         self.assertEqual(mock_compress.call_count, 1)
         self.assertIsInstance(message, str)
 
+    # Ensure correct headers are added when valid config is provided
     def test_get_headers(self):
         test_config = self._test_config
         test_config["headers"] = {
@@ -240,15 +249,19 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
 
     def test_send_request(self):
         # TODO: Iron out details of test after implementation
+        pass
     
     def test_build_client(self):
         # TODO: Iron out details of test after implementation
+        pass
 
+    # Ensures non alphanumberic label characters gets replaced with underscore
     def test_sanitize_label(self):
         unsanitized_string = "key/metric@data"
         sanitized_string = sanitize_label(unsanitized_string)
         self.assertEqual(valid_string, "key_metric_data")
 
+    # Verifies that valid yaml file is parsed correctly
     def test_valid_yaml_file(self):
         valid_yml = [
             {"url": ["https://testurl.com"]},
@@ -264,12 +277,13 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         self.assertEqual(config["name"], "test_name")
         self.assertEqual(config["remote_timeout"], "30s")
 
+    # Ensures invalid filepath raises error when parsing
     def test_invalid_yaml_file(self):
         filepath = "invalid filepath"
         with self.assertRaises(ValueError):
             parse_config(filepath)
 
-
+    # Series of test cases to ensure config validation works as intended
     class TestConfig(unittest.TestCase):
         def test_valid_standard_config(self):
             config = Config({

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -253,7 +253,7 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
         valid_yml = [
             {"url": ["https://testurl.com"]},
             {"name": ["test_name"]},
-            {"remote_timeout": ["30s"]}
+            {"remote_timeout": ["30s"]},
         ]
         filepath = "./test.yml"
         with open(filepath, 'w') as file:
@@ -281,5 +281,177 @@ class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
                 config.validate()
             except as exception:
                 self.fail("valid config failed config.validate() with error:" + exception)
+        
+        def test_valid_basic_auth_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "basic_auth": {
+                    "username": "test_username",
+                    "password": "test_password",
+                }
+            })
+            try:
+                config.validate()
+            except as exception:
+                self.fail("valid config failed config.validate() with error:" + exception)
+        
+        def test_valid_bearer_token_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "bearer_token": "test_token",
+            })
+            try:
+                config.validate()
+            except as exception:
+                self.fail("valid config failed config.validate() with error:" + exception)
+        
+        def test_valid_quantiles_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "quantiles": [0.25, 0.5, 0.75],
+            })
+            try:
+                config.validate()
+            except as exception:
+                self.fail("valid config failed config.validate() with error:" + exception)
 
-        # TODO: Add other config validity test cases
+        def test_valid_histogram_boundaries_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "histogram_boundaries": [0, 5, 10],
+            })
+            try:
+                config.validate()
+            except as exception:
+                self.fail("valid config failed config.validate() with error:" + exception)
+        
+        def test_valid_tls_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "tls_config": {
+                    "ca_file": "test_ca_file",
+                    "cert_file": "test_cert_file",
+                    "key_file": "test_key_file",
+                }
+            })
+            try:
+                config.validate()
+            except as exception:
+                self.fail("valid config failed config.validate() with error:" + exception)
+        
+        def test_invalid_no_url_config(self):
+            config = Config({
+                "name": "test_name",
+                "remote_timeout": "30s",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+        
+        def test_invalid_no_name_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "remote_timeout": "30s",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+        
+        def test_invalid_no_remote_timeout_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+        
+        def test_invalid_no_username_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "basic_auth": {
+                    "password": "test_password",
+                }
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+
+        def test_invalid_no_password_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "basic_auth": {
+                    "username": "test_username",
+                }
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+
+        def test_invalid_conflicting_passwords_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "basic_auth": {
+                    "username": "test_username",
+                    "password": "test_password",
+                    "password_file": "test_password_file",
+                }
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+        
+        def test_invalid_conflicting_bearer_tokens_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "bearer_token": "test_token",
+                "bearer_token_file": "test_token_file",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+
+        def test_invalid_conflicting_auth_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "basic_auth": {
+                    "username": "test_username",
+                    "password": "test_password",
+                }
+                "bearer_token": "test_token",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+        
+        def test_invalid_quantiles_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "quantiles": "0.25, 0.5, 0.75",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()
+
+        def test_invalid_histogram_boundaries_config(self):
+            config = Config({
+                "url": "https://testurl.com",
+                "name": "test_name",
+                "remote_timeout": "30s",
+                "histogram_boundaries": "0, 5, 10",
+            })
+            with self.assertRaises(ValueError):
+                config.validate()

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -1,0 +1,72 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from opentelemetry.exporter.prometheus_remote_write import (
+    TimeSeriesData,
+    Config,
+    PrometheusRemoteWriteMetricsExporter,
+)
+from opentelemetry.metrics import get_meter_provider, set_meter_provider
+from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
+from opentelemetry.sdk.metrics.export.aggregate import (
+    ValueObserverAggregator,
+    LastValueAggregator,
+    HistogramAggregator,
+    MinMaxSumCountAggregator,
+    SumAggregator,
+)
+from opentelemetry.sdk.util import get_dict_as_key
+
+class TestPrometheusRemoteWriteMetricExporter(unittest.TestCase):
+    def setUp(self):
+        set_meter_provider(metrics.MeterProvider())
+        self._test_config = Config({
+            "url": "https://testurl.com",
+            "name": "test_name",
+            "remote_timeout": "30s",
+        })
+        self._meter = get_meter_provider().get_meter(__name__)
+        self._test_metric = self._meter.create_counter(
+            "testname", "testdesc", "unit", int,
+        )
+        labels = {"environment": "staging"}
+        self._labels_key = get_dict_as_key(labels)
+
+    def test_export(self):
+        record = MetricRecord(
+            self._test_metric,
+            self._labels_key,
+            SumAggregator(),
+            get_meter_provider().resource,
+        )
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        result = exporter.export([record])
+        self.assertIs(result, MetricsExportResult.SUCCESS)
+    
+    def test_convert_from_sum(self):
+        sum_record = MetricRecord(
+            self._test_metric,
+            self._labels_key,
+            SumAggregator(),
+            get_meter_provider().resource,
+        )
+        sum_record.aggregator.update(5)
+        expected_timeseries = TimeSeriesData(["testname"], [5])
+        exporter = PrometheusRemoteWriteMetricsExporter(self._test_config)
+        timeseries = exporter.convert_from_sum(sum_record)
+        self.assertEqual(timeseries, expected_timeseries)
+    


### PR DESCRIPTION
## Python Exporter PR as listed on Project Kanban Board
Adds unit tests for PrometheusRemoteWriteMetricsExporter.
Creates all necessary classes with unimplemented methods (to be implemented in subsequent PRs).

When we make this PR upstream on the python-contrib repo, we will split the skeleton, exporter tests and config tests into 3 separate PRs. This PR is just so we can start implementing methods concurrently on open-o11y.