### PR TITLE
Change AttributeValue sequences from optional to nonoptional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
+
+### Changed
 - Changed AttributeValue sequences to warn mypy users on adding None values to array
   ([#1855](https://github.com/open-telemetry/opentelemetry-python/pull/1855))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
 - Fixed sequence values in OTLP exporter not translating
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
+- Changed AttributeValue sequences to warn mypy users on adding None values to array
+  (TBD)
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
+- Changed AttributeValue sequences to warn mypy users on adding None values to array
+  ([#1855](https://github.com/open-telemetry/opentelemetry-python/pull/1855))
 
 ## [1.2.0, 0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 
@@ -36,8 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
 - Fixed sequence values in OTLP exporter not translating
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
-- Changed AttributeValue sequences to warn mypy users on adding None values to array
-  (TBD)
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -20,10 +20,10 @@ AttributeValue = Union[
     bool,
     int,
     float,
-    Sequence[Optional[str]],
-    Sequence[Optional[bool]],
-    Sequence[Optional[int]],
-    Sequence[Optional[float]],
+    Sequence[str],
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
 ]
 Attributes = Optional[Mapping[str, AttributeValue]]
 AttributesAsKey = Tuple[


### PR DESCRIPTION
# Description

Per [attribute specifications](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.1.0/specification/common/common.md#attributes), `None` values should be discouraged in AttributeValues, but Python cannot actually prevent `None` values. Thus, the new changes will ensure that mypy users will be alerted when trying to add None to an AttributeValue array, without altering the current code that may continue to accept None.

Fixes issue open-telemetry/opentelemetry-python/issues/1738

## Type of change
This is a simple bug fix that will help mypy users conform with specifications.

# How Has This Been Tested?
Running the following test suites returned a clean report:
```
tox -e test-core-api
tox -e mypy
```

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Alerts to mypy users are confirmed to work when adding invalid values.