### PR TITLE
Update otel-exporter OTLP headers parsing to match format specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
+- Fixed exporter OTLP header parsing to match baggage header formatting.
+  (TBD)
 
 ## [1.2.0, 0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
+
+### Changed
 - Fixed exporter OTLP header parsing to match baggage header formatting.
   (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
 - Fixed sequence values in OTLP exporter not translating
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
-
+- Update otel exporter OTLP header parsing to match spec
+  (TBD)
+  
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.
   ([#1797](https://github.com/open-telemetry/opentelemetry-python/pull/1797))

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -230,7 +230,7 @@ class OTLPExporterMixin(
         self._headers = headers or environ.get(OTEL_EXPORTER_OTLP_HEADERS)
         if isinstance(self._headers, str):
             self._headers = tuple(
-                tuple(item.split("=")) for item in self._headers.split(",")
+                tuple(subitem.strip() for subitem in item.split("=", maxsplit=1)) for item in self._headers.split(",")
             )
         self._timeout = timeout or int(
             environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -235,7 +235,7 @@ class OTLPExporterMixin(
                 key = key.strip().lower()
                 value = value.strip()
                 temp_headers.append(tuple([key, value]))
-            
+
             self._headers = tuple(temp_headers)
 
         self._timeout = timeout or int(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -234,7 +234,7 @@ class OTLPExporterMixin(
                 key, value = header_pair.split("=", maxsplit=1)
                 key = key.strip().lower()
                 value = value.strip()
-                temp_headers.append(tuple(key, value))
+                temp_headers.append(tuple([key, value]))
             
             self._headers = tuple(temp_headers)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -229,9 +229,15 @@ class OTLPExporterMixin(
 
         self._headers = headers or environ.get(OTEL_EXPORTER_OTLP_HEADERS)
         if isinstance(self._headers, str):
-            self._headers = tuple(
-                tuple(subitem.strip() for subitem in item.split("=", maxsplit=1)) for item in self._headers.split(",")
-            )
+            temp_headers = []
+            for header_pair in self._headers.split(","):
+                key, value = header_pair.split("=", maxsplit=1)
+                key = key.strip().lower()
+                value = value.strip()
+                temp_headers.append(tuple(key, value))
+            
+            self._headers = tuple(temp_headers)
+
         self._timeout = timeout or int(
             environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10)
         )

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -180,7 +180,7 @@ class TestOTLPSpanExporter(TestCase):
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "collector:4317",
             OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE: THIS_DIR
             + "/fixtures/test.cert",
-            OTEL_EXPORTER_OTLP_TRACES_HEADERS: "key1=value1,key2=value2",
+            OTEL_EXPORTER_OTLP_TRACES_HEADERS: " key1=value1,KEY2 = value=2",
             OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "10",
             OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "gzip",
         },
@@ -195,7 +195,7 @@ class TestOTLPSpanExporter(TestCase):
         _, kwargs = mock_exporter_mixin.call_args_list[0]
 
         self.assertEqual(kwargs["endpoint"], "collector:4317")
-        self.assertEqual(kwargs["headers"], "key1=value1,key2=value2")
+        self.assertEqual(kwargs["headers"], " key1=value1,KEY2 = value=2")
         self.assertEqual(kwargs["timeout"], 10)
         self.assertEqual(kwargs["compression"], Compression.Gzip)
         self.assertIsNotNone(kwargs["credentials"])
@@ -217,7 +217,7 @@ class TestOTLPSpanExporter(TestCase):
 
     @patch.dict(
         "os.environ",
-        {OTEL_EXPORTER_OTLP_TRACES_HEADERS: "key1=value1,key2=value2"},
+        {OTEL_EXPORTER_OTLP_TRACES_HEADERS: " key1=value1,KEY2 = VALUE=2 "},
     )
     @patch(
         "opentelemetry.exporter.otlp.proto.grpc.exporter.ssl_channel_credentials"
@@ -228,7 +228,7 @@ class TestOTLPSpanExporter(TestCase):
         exporter = OTLPSpanExporter()
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key1", "value1"), ("key2", "value2"))
+            exporter._headers, (("key1", "value1"), ("key2", "VALUE=2"))
         )
         exporter = OTLPSpanExporter(
             headers=(("key3", "value3"), ("key4", "value4"))


### PR DESCRIPTION
# Description

This PR fixes the way the otel Python Exporter parses OTEL_EXPORTER_OTLP_HEADERS to align with the [otel exporter specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables). Now, the headers, which are represented in a format matching the [W3C Correlation-Context specs for HTTP header formats.](https://github.com/w3c/baggage/blob/master/baggage/HTTP_HEADER_FORMAT.md), are correctly parsed:

Fixes [#1851](https://github.com/open-telemetry/opentelemetry-python/issues/1851) by casting key string to lowercase, and [#1852](https://github.com/open-telemetry/opentelemetry-python/issues/1852) by correctly splitting on just the first equals sign `'='` and removing optional white spaces (OWS). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `tox -e test-exporter-otlp-proto-grpc` successfully completes.

# Does This PR Require a Contrib Repo Change?
I don't believe so? If I'm wrong, would someone please let me know? Thanks!!

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
