### PR TITLE
Implement CreateKey functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1823](https://github.com/open-telemetry/opentelemetry-python/pull/1823))
 - Added support for OTEL_SERVICE_NAME.
   ([#1829](https://github.com/open-telemetry/opentelemetry-python/pull/1829))
+- Added support for CreateKey functionality.
+  (TDB)
 
 ### Changed
 - Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
+- Added support for CreateKey functionality.
+  ([#1853](https://github.com/open-telemetry/opentelemetry-python/pull/1853))
 
 ## [1.2.0, 0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 
@@ -15,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1823](https://github.com/open-telemetry/opentelemetry-python/pull/1823))
 - Added support for OTEL_SERVICE_NAME.
   ([#1829](https://github.com/open-telemetry/opentelemetry-python/pull/1829))
-- Added support for CreateKey functionality.
-  (TDB)
 
 ### Changed
 - Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.

--- a/opentelemetry-api/src/opentelemetry/baggage/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/__init__.py
@@ -15,10 +15,10 @@
 import typing
 from types import MappingProxyType
 
-from opentelemetry.context import get_value, set_value
+from opentelemetry.context import create_key, get_value, set_value
 from opentelemetry.context.context import Context
 
-_BAGGAGE_KEY = "baggage"
+_BAGGAGE_KEY = create_key("baggage")
 
 
 def get_all(

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -78,7 +78,7 @@ def create_key(keyname: str) -> str:
     Returns:
         A unique string representing the newly created key.
     """
-    return str(uuid.uuid4())
+    return keyname + '-' + str(uuid.uuid4())
 
 
 def get_value(key: str, context: typing.Optional[Context] = None) -> "object":

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -15,6 +15,7 @@
 import logging
 import threading
 import typing
+import uuid
 from functools import wraps
 from os import environ
 
@@ -66,6 +67,18 @@ def _load_runtime_context(func: _F) -> _F:
         return func(*args, **kwargs)  # type: ignore[misc]
 
     return typing.cast(_F, wrapper)  # type: ignore[misc]
+
+
+def create_key(keyname: str) -> str:
+    """To allow cross-cutting concern to control access to their local state,
+    the RuntimeContext API provides a function which takes a keyname as input,
+    and returns a unique key string.
+    Args:
+        keyname: The key name for debugging purposes and is not unique.
+    Returns:
+        A new unique string representing the newly created key.
+    """
+    return str(uuid.uuid4())
 
 
 def get_value(key: str, context: typing.Optional[Context] = None) -> "object":

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -72,11 +72,11 @@ def _load_runtime_context(func: _F) -> _F:
 def create_key(keyname: str) -> str:
     """To allow cross-cutting concern to control access to their local state,
     the RuntimeContext API provides a function which takes a keyname as input,
-    and returns a unique key string.
+    and returns a unique key.
     Args:
-        keyname: The key name for debugging purposes and is not unique.
+        keyname: The key name is for debugging purposes and is not unique.
     Returns:
-        A new unique string representing the newly created key.
+        A unique string representing the newly created key.
     """
     return str(uuid.uuid4())
 

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -74,11 +74,11 @@ def create_key(keyname: str) -> str:
     the RuntimeContext API provides a function which takes a keyname as input,
     and returns a unique key.
     Args:
-        keyname: The key name is for debugging purposes and is not unique.
+        keyname: The key name is for debugging purposes and is not required to be unique.
     Returns:
         A unique string representing the newly created key.
     """
-    return keyname + '-' + str(uuid.uuid4())
+    return keyname + "-" + str(uuid.uuid4())
 
 
 def get_value(key: str, context: typing.Optional[Context] = None) -> "object":

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 from typing import Optional
 
-from opentelemetry.context import get_value, set_value
+from opentelemetry.context import create_key, get_value, set_value
 from opentelemetry.context.context import Context
 from opentelemetry.trace.span import INVALID_SPAN, Span
 
-SPAN_KEY = "current-span"
+SPAN_KEY = create_key("current-span")
 
 
 def set_span_in_context(

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -26,19 +26,29 @@ class TestContext(unittest.TestCase):
     def setUp(self):
         context.attach(Context())
 
+    def test_context_key(self):
+        key1 = context.create_key("say")
+        key2 = context.create_key("say")
+        self.assertNotEqual(key1, key2)
+        first = context.set_value(key1, "foo")
+        second = context.set_value(key2, "bar")
+        self.assertEqual(context.get_value(key1, context=first), "foo")
+        self.assertEqual(context.get_value(key2, context=second), "bar")
+
     def test_context(self):
-        self.assertIsNone(context.get_value("say"))
+        key = context.create_key("say")
+        self.assertIsNone(context.get_value(key))
         empty = context.get_current()
-        second = context.set_value("say", "foo")
-        self.assertEqual(context.get_value("say", context=second), "foo")
+        second = context.set_value(key, "foo")
+        self.assertEqual(context.get_value(key, context=second), "foo")
 
         do_work()
-        self.assertEqual(context.get_value("say"), "bar")
+        self.assertEqual(context.get_value(key), "bar")
         third = context.get_current()
 
-        self.assertIsNone(context.get_value("say", context=empty))
-        self.assertEqual(context.get_value("say", context=second), "foo")
-        self.assertEqual(context.get_value("say", context=third), "bar")
+        self.assertIsNone(context.get_value(key, context=empty))
+        self.assertEqual(context.get_value(key, context=second), "foo")
+        self.assertEqual(context.get_value(key, context=third), "bar")
 
     def test_set_value(self):
         first = context.set_value("a", "yyy")

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -18,8 +18,10 @@ from opentelemetry import context
 from opentelemetry.context.context import Context
 
 
-def do_work() -> None:
-    context.attach(context.set_value("say", "bar"))
+def do_work() -> str:
+    key = context.create_key("say")
+    context.attach(context.set_value(key, "bar"))
+    return key
 
 
 class TestContext(unittest.TestCase):
@@ -36,19 +38,19 @@ class TestContext(unittest.TestCase):
         self.assertEqual(context.get_value(key2, context=second), "bar")
 
     def test_context(self):
-        key = context.create_key("say")
-        self.assertIsNone(context.get_value(key))
+        key1 = context.create_key("say")
+        self.assertIsNone(context.get_value(key1))
         empty = context.get_current()
-        second = context.set_value(key, "foo")
-        self.assertEqual(context.get_value(key, context=second), "foo")
+        second = context.set_value(key1, "foo")
+        self.assertEqual(context.get_value(key1, context=second), "foo")
 
-        do_work()
-        self.assertEqual(context.get_value(key), "bar")
+        key2 = do_work()
+        self.assertEqual(context.get_value(key2), "bar")
         third = context.get_current()
 
-        self.assertIsNone(context.get_value(key, context=empty))
-        self.assertEqual(context.get_value(key, context=second), "foo")
-        self.assertEqual(context.get_value(key, context=third), "bar")
+        self.assertIsNone(context.get_value(key1, context=empty))
+        self.assertEqual(context.get_value(key1, context=second), "foo")
+        self.assertEqual(context.get_value(key2, context=third), "bar")
 
     def test_set_value(self):
         first = context.set_value("a", "yyy")

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -28,7 +28,6 @@ from opentelemetry.propagators.textmap import DefaultGetter
 from opentelemetry.trace.propagation import SPAN_KEY
 
 
-
 def get_child_parent_new_carrier(old_carrier, propagator):
 
     ctx = propagator.extract(old_carrier)

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -19,7 +19,7 @@ from unittest.mock import Mock
 import opentelemetry.sdk.trace as trace
 import opentelemetry.sdk.trace.id_generator as id_generator
 import opentelemetry.trace as trace_api
-from opentelemetry.context import Context, create_key, get_current
+from opentelemetry.context import Context, get_current
 from opentelemetry.propagators.b3 import (  # pylint: disable=no-name-in-module,import-error
     B3MultiFormat,
     B3SingleFormat,

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -19,12 +19,14 @@ from unittest.mock import Mock
 import opentelemetry.sdk.trace as trace
 import opentelemetry.sdk.trace.id_generator as id_generator
 import opentelemetry.trace as trace_api
-from opentelemetry.context import Context, get_current
+from opentelemetry.context import Context, create_key, get_current
 from opentelemetry.propagators.b3 import (  # pylint: disable=no-name-in-module,import-error
     B3MultiFormat,
     B3SingleFormat,
 )
 from opentelemetry.propagators.textmap import DefaultGetter
+from opentelemetry.trace.propagation import SPAN_KEY
+
 
 
 def get_child_parent_new_carrier(old_carrier, propagator):
@@ -247,7 +249,7 @@ class AbstractB3FormatTestCase:
             },
             old_ctx,
         )
-        self.assertIn("current-span", new_ctx)
+        self.assertIn(SPAN_KEY, new_ctx)
         for key, value in old_ctx.items():  # pylint:disable=no-member
             self.assertIn(key, new_ctx)
             # pylint:disable=unsubscriptable-object
@@ -257,7 +259,7 @@ class AbstractB3FormatTestCase:
         """Ensure returned context is derived from the given context."""
         old_ctx = Context({"k2": "v2"})
         new_ctx = self.get_propagator().extract({}, old_ctx)
-        self.assertNotIn("current-span", new_ctx)
+        self.assertNotIn(SPAN_KEY, new_ctx)
         for key, value in old_ctx.items():  # pylint:disable=no-member
             self.assertIn(key, new_ctx)
             # pylint:disable=unsubscriptable-object

--- a/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
+++ b/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
@@ -20,7 +20,7 @@ import opentelemetry.sdk.trace.id_generator as id_generator
 import opentelemetry.trace as trace_api
 from opentelemetry import baggage
 from opentelemetry.baggage import _BAGGAGE_KEY
-from opentelemetry.context import Context, create_key
+from opentelemetry.context import Context
 from opentelemetry.propagators import (  # pylint: disable=no-name-in-module
     jaeger,
 )

--- a/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
+++ b/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
@@ -19,7 +19,8 @@ import opentelemetry.sdk.trace as trace
 import opentelemetry.sdk.trace.id_generator as id_generator
 import opentelemetry.trace as trace_api
 from opentelemetry import baggage
-from opentelemetry.context import Context
+from opentelemetry.baggage import _BAGGAGE_KEY
+from opentelemetry.context import Context, create_key
 from opentelemetry.propagators import (  # pylint: disable=no-name-in-module
     jaeger,
 )
@@ -134,7 +135,7 @@ class TestJaegerPropagator(unittest.TestCase):
         input_baggage = {"key1": "value1"}
         _, new_carrier = get_context_new_carrier(old_carrier, input_baggage)
         ctx = FORMAT.extract(new_carrier)
-        self.assertDictEqual(input_baggage, ctx["baggage"])
+        self.assertDictEqual(input_baggage, ctx[_BAGGAGE_KEY])
 
     def test_non_string_baggage(self):
         old_carrier = {FORMAT.TRACE_ID_KEY: self.serialized_uber_trace_id}
@@ -142,7 +143,7 @@ class TestJaegerPropagator(unittest.TestCase):
         formatted_baggage = {"key1": "1", "key2": "True"}
         _, new_carrier = get_context_new_carrier(old_carrier, input_baggage)
         ctx = FORMAT.extract(new_carrier)
-        self.assertDictEqual(formatted_baggage, ctx["baggage"])
+        self.assertDictEqual(formatted_baggage, ctx[_BAGGAGE_KEY])
 
     def test_extract_invalid_uber_trace_id(self):
         old_carrier = {
@@ -153,7 +154,7 @@ class TestJaegerPropagator(unittest.TestCase):
         context = FORMAT.extract(old_carrier)
         span_context = trace_api.get_current_span(context).get_span_context()
         self.assertEqual(span_context.span_id, trace_api.INVALID_SPAN_ID)
-        self.assertDictEqual(formatted_baggage, context["baggage"])
+        self.assertDictEqual(formatted_baggage, context[_BAGGAGE_KEY])
 
     def test_extract_invalid_trace_id(self):
         old_carrier = {
@@ -164,7 +165,7 @@ class TestJaegerPropagator(unittest.TestCase):
         context = FORMAT.extract(old_carrier)
         span_context = trace_api.get_current_span(context).get_span_context()
         self.assertEqual(span_context.trace_id, trace_api.INVALID_TRACE_ID)
-        self.assertDictEqual(formatted_baggage, context["baggage"])
+        self.assertDictEqual(formatted_baggage, context[_BAGGAGE_KEY])
 
     def test_extract_invalid_span_id(self):
         old_carrier = {
@@ -175,7 +176,7 @@ class TestJaegerPropagator(unittest.TestCase):
         context = FORMAT.extract(old_carrier)
         span_context = trace_api.get_current_span(context).get_span_context()
         self.assertEqual(span_context.span_id, trace_api.INVALID_SPAN_ID)
-        self.assertDictEqual(formatted_baggage, context["baggage"])
+        self.assertDictEqual(formatted_baggage, context[_BAGGAGE_KEY])
 
     def test_fields(self):
         tracer = trace.TracerProvider().get_tracer("sdk_tracer_provider")

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -100,7 +100,14 @@ from opentracing import (
 )
 
 from opentelemetry.baggage import get_baggage, set_baggage
-from opentelemetry.context import Context, attach, detach, get_value, set_value
+from opentelemetry.context import (
+    Context,
+    attach,
+    create_key,
+    detach,
+    get_value,
+    set_value,
+)
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.shim.opentracing_shim import util
 from opentelemetry.shim.opentracing_shim.version import __version__
@@ -117,6 +124,7 @@ from opentelemetry.util.types import Attributes
 
 ValueT = TypeVar("ValueT", int, float, bool, str)
 logger = logging.getLogger(__name__)
+KEY = create_key("scope_shim")
 
 
 def create_tracer(otel_tracer_provider: TracerProvider) -> "TracerShim":
@@ -348,7 +356,7 @@ class ScopeShim(Scope):
     ):
         super().__init__(manager, span)
         self._span_cm = span_cm
-        self._token = attach(set_value("scope_shim", self))
+        self._token = attach(set_value(KEY, self))
 
     # TODO: Change type of `manager` argument to `opentracing.ScopeManager`? We
     # need to get rid of `manager.tracer` for this.

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -100,7 +100,14 @@ from opentracing import (
 )
 
 from opentelemetry.baggage import get_baggage, set_baggage
-from opentelemetry.context import Context, attach, detach, get_value, set_value
+from opentelemetry.context import (
+    Context,
+    attach,
+    create_key,
+    detach,
+    get_value,
+    set_value,
+)
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.shim.opentracing_shim import util
 from opentelemetry.shim.opentracing_shim.version import __version__
@@ -117,6 +124,7 @@ from opentelemetry.util.types import Attributes
 
 ValueT = TypeVar("ValueT", int, float, bool, str)
 logger = logging.getLogger(__name__)
+SHIM_KEY = create_key("scope_shim")
 
 
 def create_tracer(otel_tracer_provider: TracerProvider) -> "TracerShim":
@@ -348,7 +356,7 @@ class ScopeShim(Scope):
     ):
         super().__init__(manager, span)
         self._span_cm = span_cm
-        self._token = attach(set_value("scope_shim", self))
+        self._token = attach(set_value(SHIM_KEY, self))
 
     # TODO: Change type of `manager` argument to `opentracing.ScopeManager`? We
     # need to get rid of `manager.tracer` for this.
@@ -477,7 +485,7 @@ class ScopeManagerShim(ScopeManager):
             return None
 
         try:
-            return get_value("scope_shim")
+            return get_value(SHIM_KEY)
         except KeyError:
             span_context = SpanContextShim(span.get_span_context())
             wrapped_span = SpanShim(self._tracer, span_context, span)

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -100,14 +100,7 @@ from opentracing import (
 )
 
 from opentelemetry.baggage import get_baggage, set_baggage
-from opentelemetry.context import (
-    Context,
-    attach,
-    create_key,
-    detach,
-    get_value,
-    set_value,
-)
+from opentelemetry.context import Context, attach, detach, get_value, set_value
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.shim.opentracing_shim import util
 from opentelemetry.shim.opentracing_shim.version import __version__
@@ -124,7 +117,6 @@ from opentelemetry.util.types import Attributes
 
 ValueT = TypeVar("ValueT", int, float, bool, str)
 logger = logging.getLogger(__name__)
-KEY = create_key("scope_shim")
 
 
 def create_tracer(otel_tracer_provider: TracerProvider) -> "TracerShim":
@@ -356,7 +348,7 @@ class ScopeShim(Scope):
     ):
         super().__init__(manager, span)
         self._span_cm = span_cm
-        self._token = attach(set_value(KEY, self))
+        self._token = attach(set_value("scope_shim", self))
 
     # TODO: Change type of `manager` argument to `opentracing.ScopeManager`? We
     # need to get rid of `manager.tracer` for this.


### PR DESCRIPTION
This PR implements the CreateKey functionality such that it aligns partially with the [context specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.1.0/specification/context/context.md#create-a-key) and does not make any breaking changes to the API. 

Like before, the Opentelemetry-python context uses strings as input to keys for context. However, changes have been made such that it now first goes through `create_key` to generate a unique key for every inputted key names. 

> Multiple calls to CreateKey with the same name SHOULD NOT return the same value unless language constraints dictate otherwise. Different languages may impose different restrictions on the expected types, so this parameter remains an implementation detail.

The following part of the specification is not been met (as discussed with @ codeboten) in order to avoid breaking changes in the API.
> The API MUST return an opaque object representing the newly created key.

Key implementation detail:

* `create_key` method to create a new unique key string every time it is called. 
* The outputted key from `create_key` gets inputted into `get_value` and `set_value methods`.
* Added unit tests for the `create_key` method.
* Updated b3 and jaeger propagator unit tests to work with unique keys.

Fixes # (1737)
The relevant issue is not linked to avoid having this PR referenced in the issue conversation upstream

**Type of change**

* [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

New unit tests were added to ensure that same `key name` does not generate the same `key`. 
`tox` was ran to ensure the new and existing unit tests all pass. 



**Checklist:**

* [x] Followed the style guidelines of this project
* [x] Changelogs have been updated
* [x] Unit tests have been added

cc @alolita 