### PR TITLE
remove `X-B3-ParentSpanId` for B3 propagator as per OpenTelemetry Specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.2-0.25b2](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.2-0.25b2) - 2021-10-19
 
+- remove `X-B3-ParentSpanId` for B3 propagator as per OpenTelemetry specification
+  ([#2237](https://github.com/open-telemetry/opentelemetry-python/pull/2237))
 
 ## [1.6.1-0.25b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.1-0.25b1) - 2021-10-18
 

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -40,6 +40,7 @@ class B3MultiFormat(TextMapPropagator):
     SINGLE_HEADER_KEY = "b3"
     TRACE_ID_KEY = "x-b3-traceid"
     SPAN_ID_KEY = "x-b3-spanid"
+    PARENT_SPAN_ID_KEY = "x-b3-parentspanid"
     SAMPLED_KEY = "x-b3-sampled"
     FLAGS_KEY = "x-b3-flags"
     _SAMPLE_PROPAGATE_VALUES = set(["1", "True", "true", "d"])
@@ -148,6 +149,13 @@ class B3MultiFormat(TextMapPropagator):
         setter.set(
             carrier, self.SPAN_ID_KEY, format_span_id(span_context.span_id)
         )
+        span_parent = getattr(span, "parent", None)
+        if span_parent is not None:
+            setter.set(
+                carrier,
+                self.PARENT_SPAN_ID_KEY,
+                format_span_id(span_parent.span_id),
+            )
         setter.set(carrier, self.SAMPLED_KEY, "1" if sampled else "0")
 
     @property
@@ -155,6 +163,7 @@ class B3MultiFormat(TextMapPropagator):
         return {
             self.TRACE_ID_KEY,
             self.SPAN_ID_KEY,
+            self.PARENT_SPAN_ID_KEY,
             self.SAMPLED_KEY,
         }
 

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -186,10 +186,6 @@ class B3SingleFormat(B3MultiFormat):
             "1" if sampled else "0",
         ]
 
-        span_parent = getattr(span, "parent", None)
-        if span_parent:
-            fields.append(format_span_id(span_parent.span_id))
-
         setter.set(carrier, self.SINGLE_HEADER_KEY, "-".join(fields))
 
     @property

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -40,7 +40,6 @@ class B3MultiFormat(TextMapPropagator):
     SINGLE_HEADER_KEY = "b3"
     TRACE_ID_KEY = "x-b3-traceid"
     SPAN_ID_KEY = "x-b3-spanid"
-    PARENT_SPAN_ID_KEY = "x-b3-parentspanid"
     SAMPLED_KEY = "x-b3-sampled"
     FLAGS_KEY = "x-b3-flags"
     _SAMPLE_PROPAGATE_VALUES = set(["1", "True", "true", "d"])
@@ -149,13 +148,6 @@ class B3MultiFormat(TextMapPropagator):
         setter.set(
             carrier, self.SPAN_ID_KEY, format_span_id(span_context.span_id)
         )
-        span_parent = getattr(span, "parent", None)
-        if span_parent is not None:
-            setter.set(
-                carrier,
-                self.PARENT_SPAN_ID_KEY,
-                format_span_id(span_parent.span_id),
-            )
         setter.set(carrier, self.SAMPLED_KEY, "1" if sampled else "0")
 
     @property
@@ -163,7 +155,6 @@ class B3MultiFormat(TextMapPropagator):
         return {
             self.TRACE_ID_KEY,
             self.SPAN_ID_KEY,
-            self.PARENT_SPAN_ID_KEY,
             self.SAMPLED_KEY,
         }
 

--- a/propagator/opentelemetry-propagator-b3/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py
@@ -36,7 +36,6 @@ def test_inject_empty_context(benchmark):
                 {
                     FORMAT.TRACE_ID_KEY: "bdb5b63237ed38aea578af665aa5aa60",
                     FORMAT.SPAN_ID_KEY: "00000000000000000c32d953d73ad225",
-                    FORMAT.PARENT_SPAN_ID_KEY: "11fd79a30b0896cd285b396ae102dd76",
                     FORMAT.SAMPLED_KEY: "1",
                 },
             )

--- a/propagator/opentelemetry-propagator-b3/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py
@@ -22,7 +22,7 @@ def test_extract_single_header(benchmark):
     benchmark(
         FORMAT.extract,
         {
-            FORMAT.SINGLE_HEADER_KEY: "bdb5b63237ed38aea578af665aa5aa60-c32d953d73ad2251-1-11fd79a30b0896cd285b396ae102dd76"
+            FORMAT.SINGLE_HEADER_KEY: "bdb5b63237ed38aea578af665aa5aa60-c32d953d73ad2251-1"
         },
     )
 

--- a/propagator/opentelemetry-propagator-b3/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py
@@ -36,6 +36,7 @@ def test_inject_empty_context(benchmark):
                 {
                     FORMAT.TRACE_ID_KEY: "bdb5b63237ed38aea578af665aa5aa60",
                     FORMAT.SPAN_ID_KEY: "00000000000000000c32d953d73ad225",
+                    FORMAT.PARENT_SPAN_ID_KEY: "11fd79a30b0896cd285b396ae102dd76",
                     FORMAT.SAMPLED_KEY: "1",
                 },
             )

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -65,9 +65,6 @@ class AbstractB3FormatTestCase:
         cls.serialized_span_id = trace_api.format_span_id(
             generator.generate_span_id()
         )
-        cls.serialized_parent_id = trace_api.format_span_id(
-            generator.generate_span_id()
-        )
 
     def setUp(self) -> None:
         tracer_provider = trace.TracerProvider()
@@ -141,7 +138,7 @@ class AbstractB3FormatTestCase:
 
         child, parent, _ = self.get_child_parent_new_carrier(
             {
-                propagator.SINGLE_HEADER_KEY: f"{self.serialized_trace_id}-{self.serialized_span_id}-1-{self.serialized_parent_id}"
+                propagator.SINGLE_HEADER_KEY: f"{self.serialized_trace_id}-{self.serialized_span_id}-1"
             }
         )
 

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -103,6 +103,7 @@ class AbstractB3FormatTestCase:
         context = {
             propagator.TRACE_ID_KEY: self.serialized_trace_id,
             propagator.SPAN_ID_KEY: self.serialized_span_id,
+            propagator.PARENT_SPAN_ID_KEY: self.serialized_parent_id,
             propagator.SAMPLED_KEY: "1",
         }
         child, parent, _ = self.get_child_parent_new_carrier(context)

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -103,7 +103,6 @@ class AbstractB3FormatTestCase:
         context = {
             propagator.TRACE_ID_KEY: self.serialized_trace_id,
             propagator.SPAN_ID_KEY: self.serialized_span_id,
-            propagator.PARENT_SPAN_ID_KEY: self.serialized_parent_id,
             propagator.SAMPLED_KEY: "1",
         }
         child, parent, _ = self.get_child_parent_new_carrier(context)


### PR DESCRIPTION
This PR is to remove `X-B3-ParentSpanId` for B3 propagator as per B3 Requirements in [OpenTelemetry Specification Propagators API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#b3-inject): 

> MUST NOT propagate X-B3-ParentSpanId as OpenTelemetry does not support reusing the same id for both sides of a request.

Fixes issue # 2231
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox` tests

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
